### PR TITLE
Calculate ascent based on the bounding box

### DIFF
--- a/bdf.c
+++ b/bdf.c
@@ -127,7 +127,10 @@ int bdf_convert(const char *name, unsigned gmin, unsigned gmax, unsigned ascende
             dx = strtoul(arg, &arg, 10);
             dy = strtoul(arg, &arg, 10);
             strtoul(arg, &arg, 10);
-            strtoul(arg, &arg, 10);
+            int fbb_oy = strtoul(arg, &arg, 10);
+            // Calculate the ascent based on the bounding box because the font may have
+            // pixels that lie above or below the official ascent/descent values.
+            ascent = dy + fbb_oy;
             // Calculate the number of bytes needed to store a line of the glyph
             bytes = (dx + 7) / 8;
         }
@@ -135,7 +138,9 @@ int bdf_convert(const char *name, unsigned gmin, unsigned gmax, unsigned ascende
         {
             if (!mute && (flags & BDF_HEADER))
                 printf("// %s\n", buf);
-            ascent = strtoul(arg, &arg, 10);
+            unsigned official_ascent = strtoul(arg, &arg, 10);
+            ascent = official_ascent > ascent ? official_ascent : ascent;
+
         }
         if (key_arg(buf, "FONT_DESCENT", &arg))
         {


### PR DESCRIPTION
Font ascent/descent _should_ indicate how many pixels above/below the baseline the font uses. This isn't actually enforced though, so fonts can end up with pixels outside of that range, leading to a bounding box with a height greater than ascent + descent. This change calculates an ascent value based on the bounding box, and uses the greater of that calculated value or the official ascent from the file.